### PR TITLE
fix: Remove queen orderBy nonsense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "gatsby-source-filesystem": "3.5.0",
         "gatsby-transformer-sharp": "3.5.0",
         "googleapis": "71.0.0",
-        "lodash": "4.17.21",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-helmet": "6.1.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gatsby-source-filesystem": "3.5.0",
     "gatsby-transformer-sharp": "3.5.0",
     "googleapis": "71.0.0",
-    "lodash": "4.17.21",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "6.1.0"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React from "react"
 import { useStaticQuery, graphql, Link } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
-import { orderBy } from "lodash"
 
 const IndexPage = () => {
   const data = useStaticQuery(graphql`
@@ -26,38 +25,14 @@ const IndexPage = () => {
           gatsbyPath(filePath: "/{youTube.slug}")
           snippet {
             publishedAt
-            liveBroadcastContent
             title
-            thumbnails {
-              default {
-                url
-                height
-                width
-              }
-            }
           }
         }
       }
     }
   `)
 
-  const treasure = orderBy(
-    data.allYouTube.nodes,
-    [
-      ({ snippet }) => {
-        switch (snippet.liveBroadcastContent) {
-          case "upcoming":
-            return 3
-          case "live":
-            return 2
-          default:
-            return 1
-        }
-      },
-      "snippet.publishedAt",
-    ],
-    ["desc", "desc"]
-  )
+  const treasure = data.allYouTube.nodes
 
   return (
     <main style={{ maxWidth: "800px", margin: "0 auto" }}>
@@ -76,11 +51,7 @@ const IndexPage = () => {
           <li key={index}>
             <Link to={video.gatsbyPath}>
               <h3>
-                {`#${treasure.length - index} `}{" "}
-                {video.snippet.title
-                  .replace(" · #GatsbyJS Deep Dive", "")
-                  .replace("🔴🍻", "")
-                  .replace("🔴 🍻", "")}
+                {`#${treasure.length - index} `} {video.snippet.title}
               </h3>
 
               <GatsbyImage


### PR DESCRIPTION
Tried to make quick fix to get the videos to show up in the correct order. Did not work in the end as YouTube does some weird things with publishedAt. We need to get access to the date it is actually streamed.